### PR TITLE
Fix broken markdown links

### DIFF
--- a/demos/demos.md
+++ b/demos/demos.md
@@ -3,18 +3,18 @@
 ## C#
 A basic demo utilizing .NET Core 2.0 to showcase a participant request with optional filtering.
 
-[Download](demos/csharp)
+[Download](csharp)
 
 ## JavaScript
 Launching index.html will open a page that you can use to generate JavaScript code snippets to call the DonorDrive Public API.
 You can also use the page to hit the Public API and view the results.  It is suggested that you read the main README before using this page.
 
-[Download](demos/javascript)
+[Download](javascript)
 
 ## PHP
 A basic demo using PHP to get all participants from an event.
 
-[Download](demos/php)
+[Download](php)
 
 ## Node
 The Node demo is developed and maintained by [ammuench's Github project](https://github.com/ammuench/extra-life-api)


### PR DESCRIPTION
Currently the links in the demo readme point to URLs like this:
`https://github.com/DonorDrive/PublicAPI/blob/master/demos/demos/csharp`

The "demos" portion of the URL is redundant, this fixes those links